### PR TITLE
Popup countdown before lockin only when user is idle for at least 3 seconds

### DIFF
--- a/NeedABreak/NeedABreak.csproj
+++ b/NeedABreak/NeedABreak.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Utils\RegistryTool.cs" />
     <Compile Include="Utils\SessionLock.cs" />
     <Compile Include="Utils\TextResourceExtension.cs" />
+    <Compile Include="Utils\UserActivity.cs" />
     <Page Include="AboutBoxWindow.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/NeedABreak/Utils/UserActivity.cs
+++ b/NeedABreak/Utils/UserActivity.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NeedABreak.Utils
+{
+	public class UserActivity
+	{
+		private TimeSpan _idleTime;
+
+		/// <summary>
+		/// UserActivity constructor
+		/// </summary>
+		/// <param name="idleTime">time after which the user will be considered idle.</param>
+		public UserActivity(TimeSpan idleTime)
+		{
+			if (idleTime == TimeSpan.Zero)
+			{
+				idleTime = TimeSpan.FromSeconds(2);
+			}
+
+			_idleTime = idleTime;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "<Pending>")]
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "<Pending>")]
+		public struct LASTINPUTINFO
+		{
+			public uint cbSize;
+			public uint dwTime;
+		}
+
+		[DllImport("user32.dll")]
+		static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+
+		public static TimeSpan GetInactiveTime()
+		{
+			LASTINPUTINFO info = new LASTINPUTINFO();
+			info.cbSize = (uint)Marshal.SizeOf(info);
+
+			if (GetLastInputInfo(ref info))
+			{
+				return TimeSpan.FromMilliseconds(Environment.TickCount - info.dwTime);
+			}
+			else
+			{
+				return TimeSpan.Zero;
+			}
+		}
+
+		public async Task WaitForUserToBeIdleAsync()
+		{
+			TimeSpan inactiveTime = GetInactiveTime();
+
+			while (inactiveTime < _idleTime)
+			{
+				await Task.Delay(1000);
+				inactiveTime = GetInactiveTime();
+			}			
+		}
+	}
+}

--- a/NeedABreak/Utils/UserActivity.cs
+++ b/NeedABreak/Utils/UserActivity.cs
@@ -19,7 +19,7 @@ namespace NeedABreak.Utils
 		{
 			if (idleTime == TimeSpan.Zero)
 			{
-				idleTime = TimeSpan.FromSeconds(2);
+				idleTime = TimeSpan.FromSeconds(3);
 			}
 
 			_idleTime = idleTime;


### PR DESCRIPTION
In order to prevent annoying user with a popup while they are about to make an action with the mouse or typing on the keyboard. Closes #62.