### PR TITLE
Fix P/Invoke signature typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ Use of P/Invoke to check current user notification state in order to automatical
 
 ```csharp
 [DllImport("shell32.dll")]
-static extern int SHQueryUserNotificationStte(outUserNotificationStateuserNotificationState);
+static extern int SHQueryUserNotificationState(out UserNotificationState userNotificationState);
 ```
 
 Use of P/Invoke to ensure user is idle before poping-up the countdown window:


### PR DESCRIPTION
## Summary
- correct the `SHQueryUserNotificationState` P/Invoke signature in `readme.md`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f811b476883208582bb53615d8288