### PR TITLE
Fix typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ You can install the latest version from the [Microsoft Store](https://www.micros
 
 If you prefer, you can download the version you want to install from the [Releases page](https://github.com/bNobo/needabreak/releases)
 
-> Starting with version 3.x you'll need Windows 10 minimum. If you have an older system, you should download a previous version from the Releases page. The latest version before 3.x was 2.3. Please note that previous versions won't benefit from new functionnalities and security updates. You should upgrade your system to benefit from the latest version.
+> Starting with version 3.x you'll need Windows 10 minimum. If you have an older system, you should download a previous version from the Releases page. The latest version before 3.x was 2.3. Please note that previous versions won't benefit from new functionalities and security updates. You should upgrade your system to benefit from the latest version.
 
 ## Get started
 


### PR DESCRIPTION
## Summary
- fix `functionnalities` typo in readme

## Testing
- `dotnet test NeedABreak.sln --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f80ce728c8320ad25a976a2ba15e0